### PR TITLE
#42: Fix end point middleware executed after handler & Rename middleware to middlewares

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deadlockjs",
-  "version": "1.4.18",
+  "version": "1.5.0",
   "description": "Lightweight Node.js/Express framework for building secured, clustered and well-designed APIs.",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/deadlock/DeadLock.ts
+++ b/src/deadlock/DeadLock.ts
@@ -144,8 +144,8 @@ export class DeadLock {
         const router: express.Router = express.Router({mergeParams: true});
 
         // attach the job executor(s)
-        if (parent.middleware != null && depth > 0)
-            router.use(DeadLock.buildMiddleware(parent.middleware));
+        if (parent.middlewares != null && depth > 0)
+            router.use(DeadLock.buildMiddleware(parent.middlewares));
 
         // attach directory routes
         for (const routePath in routes) {

--- a/src/deadlock/api/description/APIDirectory.ts
+++ b/src/deadlock/api/description/APIDirectory.ts
@@ -6,7 +6,7 @@ import {APIEndPointHandler} from "./APIEndPointHandler";
 export interface APIDirectory {
 
     /** one jobexecutor or more */
-    middleware?: APIMiddleware[];
+    middlewares?: APIMiddleware[];
 
     /** routes (can be directory themselves ) */
     routes: {[path: string]: APIDirectory | APIEndPoint | APIEndPointHandler};

--- a/src/deadlock/api/jobexecutor/EndPointMiddlewareExecutor.ts
+++ b/src/deadlock/api/jobexecutor/EndPointMiddlewareExecutor.ts
@@ -1,0 +1,13 @@
+import {JobExecutor} from "./JobExecutor";
+import {APIEndPoint} from "../../../index";
+import * as e from "express";
+
+export class EndPointMiddlewareExecutor extends JobExecutor {
+
+    protected async execute(endPoint: APIEndPoint, req: e.Request, res: e.Response): Promise<any> {
+
+        if (typeof endPoint.middlewares !== 'undefined')
+            await Promise.all(endPoint.middlewares.map(middleware => middleware(req, res)));
+    }
+
+}

--- a/src/deadlock/api/wrapper/RequestWrapper.ts
+++ b/src/deadlock/api/wrapper/RequestWrapper.ts
@@ -13,6 +13,7 @@ import {MongoDBCleaner} from "../jobexecutor";
 import {CacheHandler} from "../jobexecutor";
 import {RequestHandler} from "../jobexecutor";
 import {JobResult} from "../jobexecutor/JobResult";
+import {EndPointMiddlewareExecutor} from "../jobexecutor/EndPointMiddlewareExecutor";
 
 
 type PromiseGenerator<T> = () => Promise<T>;
@@ -60,6 +61,9 @@ export class RequestWrapper implements IRequestWrapper {
             [
                 new MySQLProvider(api),
                 new MongoDBProvider(api),
+            ],
+            [
+                new EndPointMiddlewareExecutor(api)
             ],
             [
                 new RequestHandler(api)
@@ -130,10 +134,6 @@ export class RequestWrapper implements IRequestWrapper {
         try {
             // run jobs
             let jobResult: JobResult = await this.executeGenerators(endPoint, req, res);
-
-            // custom middle
-            if (typeof endPoint.middlewares !== 'undefined')
-                await Promise.all(endPoint.middlewares.map(middleware => middleware(req, res)));
 
             // convert the result to string
             if (! (jobResult.executor instanceof RequestHandler) && typeof jobResult.result === 'string') {

--- a/test/test-manual.ts
+++ b/test/test-manual.ts
@@ -1,12 +1,11 @@
-import {APIDescription, RequestLocal} from "../src";
+import * as express from "express";
+
+import {APIDescription} from "../src";
 import {DeadLock} from "../src/deadlock";
-import {ObjectFilter, RegExpFilter} from "io-filter";
 
 const HOST: string = 'localhost';
 const PORT: number = 48654;
 const PATH: string = '/api/test';
-
-let counter: number = 1;
 
 const api: APIDescription = {
 
@@ -19,35 +18,32 @@ const api: APIDescription = {
     basePath: PATH,
 
     routes: {
-        // test suite 1
-        '/': async () => "ok",
 
-        // test suite 2
-        '/get1': {
-            method: 'get',
-            handler: async () => ({ a: 2 })
-        },
-        '/get2': {
-            method: 'get',
-            handler: async () => { (<any>{}).x.y = 1; return 2; }
-        },
-        '/post1': {
-            method: 'post',
-            handler: async () => ({ a: 3 })
-        },
-
-        // test suite 3
-        '/post2': {
-            method: 'post',
-            paramFilter: new ObjectFilter({user: new RegExpFilter(/^[0-9]+$/)}),
-            handler: async (dl: RequestLocal) => dl.requestInfo.params
-        },
-
-        // test suite 4
-        '/get3': {
-            method: 'get',
-            cache: { expire: 500 },
-            handler: async () => counter ++
+        '/dir': {
+            middlewares: [
+                async (req: express.Request, res: express.Response): Promise<void> => {
+                    console.log('directory middleware 1');
+                },
+                async (req: express.Request, res: express.Response): Promise<void> => {
+                    console.log('directory middleware 2');
+                }
+            ],
+            routes: {
+                '/route': {
+                    middlewares: [
+                        async (req: express.Request, res: express.Response): Promise<void> => {
+                            console.log('end point middleware 1');
+                        },
+                        async (req: express.Request, res: express.Response): Promise<void> => {
+                            console.log('end point middleware 2');
+                        },
+                    ],
+                    handler: async () => {
+                        console.log('handler');
+                        return "returned value";
+                    }
+                }
+            }
         }
     }
 };

--- a/test/test-manual.ts
+++ b/test/test-manual.ts
@@ -1,11 +1,12 @@
-import * as express from "express";
-
-import {APIDescription} from "../src";
+import {APIDescription, RequestLocal} from "../src";
 import {DeadLock} from "../src/deadlock";
+import {ObjectFilter, RegExpFilter} from "io-filter";
 
 const HOST: string = 'localhost';
 const PORT: number = 48654;
 const PATH: string = '/api/test';
+
+let counter: number = 1;
 
 const api: APIDescription = {
 
@@ -18,32 +19,35 @@ const api: APIDescription = {
     basePath: PATH,
 
     routes: {
+        // test suite 1
+        '/': async () => "ok",
 
-        '/dir': {
-            middlewares: [
-                async (req: express.Request, res: express.Response): Promise<void> => {
-                    console.log('directory middleware 1');
-                },
-                async (req: express.Request, res: express.Response): Promise<void> => {
-                    console.log('directory middleware 2');
-                }
-            ],
-            routes: {
-                '/route': {
-                    middlewares: [
-                        async (req: express.Request, res: express.Response): Promise<void> => {
-                            console.log('end point middleware 1');
-                        },
-                        async (req: express.Request, res: express.Response): Promise<void> => {
-                            console.log('end point middleware 2');
-                        },
-                    ],
-                    handler: async () => {
-                        console.log('handler');
-                        return "returned value";
-                    }
-                }
-            }
+        // test suite 2
+        '/get1': {
+            method: 'get',
+            handler: async () => ({ a: 2 })
+        },
+        '/get2': {
+            method: 'get',
+            handler: async () => { (<any>{}).x.y = 1; return 2; }
+        },
+        '/post1': {
+            method: 'post',
+            handler: async () => ({ a: 3 })
+        },
+
+        // test suite 3
+        '/post2': {
+            method: 'post',
+            paramFilter: new ObjectFilter({user: new RegExpFilter(/^[0-9]+$/)}),
+            handler: async (dl: RequestLocal) => dl.requestInfo.params
+        },
+
+        // test suite 4
+        '/get3': {
+            method: 'get',
+            cache: { expire: 500 },
+            handler: async () => counter ++
         }
     }
 };


### PR DESCRIPTION
Issue: #42

# Modifications
- Rename middleware to middlewares in APIDirectory
- Fix end point middlewares executed **after** end point handlers
